### PR TITLE
Update tslint.

### DIFF
--- a/generators/app/templates/tslint.json
+++ b/generators/app/templates/tslint.json
@@ -1,3 +1,3 @@
 {
-  "extends": "typings"
+  "extends": "tslint-config-typings"
 }


### PR DESCRIPTION
The actual `extends` feature might not do the `tslint-config-` shorthand.