### PR TITLE
Update default compiler options

### DIFF
--- a/generators/app/templates/source-test/tsconfig.json
+++ b/generators/app/templates/source-test/tsconfig.json
@@ -1,7 +1,13 @@
 {
   "compilerOptions": {
+    "lib": ["es2015"],
     "module": "commonjs",
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "noEmit": true,
+    "noImplicitAny": true,
+    "outDir": "out",
+    "strictNullChecks": true,
+    "target": "es5"
   },
   "files": [
     "../typings/index.d.ts",

--- a/generators/app/templates/tsconfig.json
+++ b/generators/app/templates/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
+    "lib": ["es2015"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "outDir": "out"
+    "noEmit": true,
+    "noImplicitAny": true,
+    "outDir": "out",
+    "strictNullChecks": true,
+    "target": "es5"
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This commit updates the templates for the `tsconfig.json` files to
follow [the guidelines](https://github.com/types/guidelines).

Amongst the changes, it explicitly defines the library, enables strict null
checks and disables implicit `any`.